### PR TITLE
Add Tests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,157 @@
+PATH
+  remote: .
+  specs:
+    bullet_train-routes (1.0.0)
+      rails (>= 6.0.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actioncable (7.0.4)
+      actionpack (= 7.0.4)
+      activesupport (= 7.0.4)
+      nio4r (~> 2.0)
+      websocket-driver (>= 0.6.1)
+    actionmailbox (7.0.4)
+      actionpack (= 7.0.4)
+      activejob (= 7.0.4)
+      activerecord (= 7.0.4)
+      activestorage (= 7.0.4)
+      activesupport (= 7.0.4)
+      mail (>= 2.7.1)
+      net-imap
+      net-pop
+      net-smtp
+    actionmailer (7.0.4)
+      actionpack (= 7.0.4)
+      actionview (= 7.0.4)
+      activejob (= 7.0.4)
+      activesupport (= 7.0.4)
+      mail (~> 2.5, >= 2.5.4)
+      net-imap
+      net-pop
+      net-smtp
+      rails-dom-testing (~> 2.0)
+    actionpack (7.0.4)
+      actionview (= 7.0.4)
+      activesupport (= 7.0.4)
+      rack (~> 2.0, >= 2.2.0)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.2.0)
+    actiontext (7.0.4)
+      actionpack (= 7.0.4)
+      activerecord (= 7.0.4)
+      activestorage (= 7.0.4)
+      activesupport (= 7.0.4)
+      globalid (>= 0.6.0)
+      nokogiri (>= 1.8.5)
+    actionview (7.0.4)
+      activesupport (= 7.0.4)
+      builder (~> 3.1)
+      erubi (~> 1.4)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    activejob (7.0.4)
+      activesupport (= 7.0.4)
+      globalid (>= 0.3.6)
+    activemodel (7.0.4)
+      activesupport (= 7.0.4)
+    activerecord (7.0.4)
+      activemodel (= 7.0.4)
+      activesupport (= 7.0.4)
+    activestorage (7.0.4)
+      actionpack (= 7.0.4)
+      activejob (= 7.0.4)
+      activerecord (= 7.0.4)
+      activesupport (= 7.0.4)
+      marcel (~> 1.0)
+      mini_mime (>= 1.1.0)
+    activesupport (7.0.4)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+    builder (3.2.4)
+    concurrent-ruby (1.1.10)
+    crass (1.0.6)
+    date (3.3.3)
+    erubi (1.12.0)
+    globalid (1.0.0)
+      activesupport (>= 5.0)
+    i18n (1.12.0)
+      concurrent-ruby (~> 1.0)
+    loofah (2.19.1)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.5.9)
+    mail (2.8.0)
+      mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
+    marcel (1.0.2)
+    method_source (1.0.0)
+    mini_mime (1.1.2)
+    minitest (5.17.0)
+    net-imap (0.3.4)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.1)
+      timeout
+    net-smtp (0.3.3)
+      net-protocol
+    nio4r (2.5.8)
+    nokogiri (1.13.10-arm64-darwin)
+      racc (~> 1.4)
+    racc (1.6.2)
+    rack (2.2.5)
+    rack-test (2.0.2)
+      rack (>= 1.3)
+    rails (7.0.4)
+      actioncable (= 7.0.4)
+      actionmailbox (= 7.0.4)
+      actionmailer (= 7.0.4)
+      actionpack (= 7.0.4)
+      actiontext (= 7.0.4)
+      actionview (= 7.0.4)
+      activejob (= 7.0.4)
+      activemodel (= 7.0.4)
+      activerecord (= 7.0.4)
+      activestorage (= 7.0.4)
+      activesupport (= 7.0.4)
+      bundler (>= 1.15.0)
+      railties (= 7.0.4)
+    rails-dom-testing (2.0.3)
+      activesupport (>= 4.2.0)
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.4.4)
+      loofah (~> 2.19, >= 2.19.1)
+    railties (7.0.4)
+      actionpack (= 7.0.4)
+      activesupport (= 7.0.4)
+      method_source
+      rake (>= 12.2)
+      thor (~> 1.0)
+      zeitwerk (~> 2.5)
+    rake (13.0.6)
+    sqlite3 (1.5.4-arm64-darwin)
+    thor (1.2.1)
+    timeout (0.3.1)
+    tzinfo (2.0.5)
+      concurrent-ruby (~> 1.0)
+    websocket-driver (0.7.5)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
+    zeitwerk (2.6.6)
+
+PLATFORMS
+  arm64-darwin-20
+
+DEPENDENCIES
+  bullet_train-routes!
+  sqlite3
+
+BUNDLED WITH
+   2.4.1

--- a/test/bullet_train/routes_test.rb
+++ b/test/bullet_train/routes_test.rb
@@ -1,7 +1,107 @@
 require "test_helper"
 
-class BulletTrain::RoutesTest < ActiveSupport::TestCase
+class BulletTrain::RoutesTest < ActionDispatch::IntegrationTest
+  setup do
+    @routes = ActionDispatch::Routing::RouteSet.new
+    @mapper = @routes.draw { break self }
+  end
+
+  delegate :namespace, :scope, :resources, :resource, :model, to: :@mapper
+  # delegate_missing_to :@mapper
+
   test "it has a version number" do
     assert BulletTrain::Routes::VERSION
+  end
+
+  test "basic model routing" do
+    model "Project"
+
+    assert_formatted_routes <<~ROUTES
+    projects GET    /projects(.:format)          projects#index
+             POST   /projects(.:format)          projects#create
+ new_project GET    /projects/new(.:format)      projects#new
+edit_project GET    /projects/:id/edit(.:format) projects#edit
+     project GET    /projects/:id(.:format)      projects#show
+             PATCH  /projects/:id(.:format)      projects#update
+             PUT    /projects/:id(.:format)      projects#update
+             DELETE /projects/:id(.:format)      projects#destroy
+    ROUTES
+  end
+
+  test "model routing with ruby namespace" do
+    model "Projects::Deliverable"
+
+    assert_formatted_routes <<~ROUTES
+    projects_deliverables GET    /projects/deliverables(.:format)          projects/deliverables#index
+                          POST   /projects/deliverables(.:format)          projects/deliverables#create
+ new_projects_deliverable GET    /projects/deliverables/new(.:format)      projects/deliverables#new
+edit_projects_deliverable GET    /projects/deliverables/:id/edit(.:format) projects/deliverables#edit
+     projects_deliverable GET    /projects/deliverables/:id(.:format)      projects/deliverables#show
+                          PATCH  /projects/deliverables/:id(.:format)      projects/deliverables#update
+                          PUT    /projects/deliverables/:id(.:format)      projects/deliverables#update
+                          DELETE /projects/deliverables/:id(.:format)      projects/deliverables#destroy
+    ROUTES
+  end
+
+  test "nested model routes" do
+    model "Project" do
+      model "Projects::Deliverable"
+    end
+
+    assert_formatted_routes <<~ROUTES
+             project_deliverables GET    /projects/:project_id/deliverables(.:format)                   projects/deliverables#index
+                                  POST   /projects/:project_id/deliverables(.:format)                   projects/deliverables#create
+          new_project_deliverable GET    /projects/:project_id/deliverables/new(.:format)               projects/deliverables#new
+edit_project_projects_deliverable GET    /projects/:project_id/projects/deliverables/:id/edit(.:format) projects/deliverables#edit
+     project_projects_deliverable GET    /projects/:project_id/projects/deliverables/:id(.:format)      projects/deliverables#show
+                                  PATCH  /projects/:project_id/projects/deliverables/:id(.:format)      projects/deliverables#update
+                                  PUT    /projects/:project_id/projects/deliverables/:id(.:format)      projects/deliverables#update
+                                  DELETE /projects/:project_id/projects/deliverables/:id(.:format)      projects/deliverables#destroy
+                         projects GET    /projects(.:format)                                            projects#index
+                                  POST   /projects(.:format)                                            projects#create
+                      new_project GET    /projects/new(.:format)                                        projects#new
+                     edit_project GET    /projects/:id/edit(.:format)                                   projects#edit
+                          project GET    /projects/:id(.:format)                                        projects#show
+                                  PATCH  /projects/:id(.:format)                                        projects#update
+                                  PUT    /projects/:id(.:format)                                        projects#update
+                                  DELETE /projects/:id(.:format)                                        projects#destroy
+    ROUTES
+
+    assert_equal_routing do
+      collection_actions = [:index, :new, :create]
+
+      resources :projects do
+        scope module: 'projects' do
+          resources :deliverables, only: collection_actions
+        end
+      end
+
+      namespace :projects do
+        resources :deliverables, except: collection_actions
+      end
+    end
+  end
+
+  private
+
+  def assert_equal_routing(&block)
+    routes = ActionDispatch::Routing::RouteSet.new
+    routes.draw(&block)
+
+    assert_equal formatted_routes, formatted_routes(routes)
+  end
+
+  def assert_formatted_routes(string)
+    routes = formatted_routes.split("\n")
+    lines = string.split("\n")
+    lines.each do |route|
+      assert_includes routes, route
+    end
+  end
+
+  def formatted_routes(routes = @routes)
+    inspector = ActionDispatch::Routing::RoutesInspector.new(routes.routes)
+    formatter = ActionDispatch::Routing::ConsoleFormatter::Sheet.new
+    inspector.format(formatter)
   end
 end

--- a/test/bullet_train/routes_test.rb
+++ b/test/bullet_train/routes_test.rb
@@ -68,7 +68,7 @@ edit_project_projects_deliverable GET    /projects/:project_id/projects/delivera
                                   DELETE /projects/:id(.:format)                                        projects#destroy
     ROUTES
 
-    assert_equal_routing do
+    assert_routing_equal_to do
       collection_actions = [:index, :new, :create]
 
       resources :projects do
@@ -85,7 +85,7 @@ edit_project_projects_deliverable GET    /projects/:project_id/projects/delivera
 
   private
 
-  def assert_equal_routing(&block)
+  def assert_routing_equal_to(&block)
     routes = ActionDispatch::Routing::RouteSet.new
     routes.draw(&block)
 

--- a/test/bullet_train/routes_test.rb
+++ b/test/bullet_train/routes_test.rb
@@ -160,10 +160,10 @@ edit_project_projects_deliverable GET    /projects/:project_id/projects/delivera
         Expected routes to be equal, but found these differences.
 
         These are the expected routes:
-          #{expected_lines.values_at(*missing_from_expected).join("\n")}
+        #{expected_lines.values_at(*missing_from_expected).join("\n")}
 
         These were the actual routes:
-          #{actual_lines.values_at(*missing_from_actual).join("\n")}
+        #{actual_lines.values_at(*missing_from_actual).join("\n")}
 
         The full expected route set is:
         #{expected}

--- a/test/bullet_train/routes_test.rb
+++ b/test/bullet_train/routes_test.rb
@@ -137,6 +137,28 @@ edit_project_projects_deliverable GET    /projects/:project_id/projects/delivera
         end
       end
     end
+
+    assert_formatted_routes <<~ROUTES
+  search_account_sites GET    /account/sites/search(.:format)                  account/sites#search
+  publish_account_site POST   /account/sites/:id/publish(.:format)             account/sites#publish
+    account_site_pages GET    /account/sites/:site_id/pages(.:format)          account/pages#index
+                       POST   /account/sites/:site_id/pages(.:format)          account/pages#create
+ new_account_site_page GET    /account/sites/:site_id/pages/new(.:format)      account/pages#new
+edit_account_site_page GET    /account/sites/:site_id/pages/:id/edit(.:format) account/pages#edit
+     account_site_page GET    /account/sites/:site_id/pages/:id(.:format)      account/pages#show
+                       PATCH  /account/sites/:site_id/pages/:id(.:format)      account/pages#update
+                       PUT    /account/sites/:site_id/pages/:id(.:format)      account/pages#update
+                       DELETE /account/sites/:site_id/pages/:id(.:format)      account/pages#destroy
+ account_site_sortable GET    /account/sites/:site_id/sortable(.:format)       account/sortable#index
+         account_sites GET    /account/sites(.:format)                         account/sites#index
+                       POST   /account/sites(.:format)                         account/sites#create
+      new_account_site GET    /account/sites/new(.:format)                     account/sites#new
+     edit_account_site GET    /account/sites/:id/edit(.:format)                account/sites#edit
+          account_site GET    /account/sites/:id(.:format)                     account/sites#show
+                       PATCH  /account/sites/:id(.:format)                     account/sites#update
+                       PUT    /account/sites/:id(.:format)                     account/sites#update
+                       DELETE /account/sites/:id(.:format)                     account/sites#destroy
+    ROUTES
   end
 
   private


### PR DESCRIPTION
Mostly adds tests to assert that the README examples generate the same routing — and then some extra assertions on the generates routes matched against the formatting from `bin/rails routes`.